### PR TITLE
Feat: Create core of lading page

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,3 @@
 <template>
-  <div>
-    <NuxtRouteAnnouncer />
-    <NuxtWelcome />
-  </div>
+  <NuxtPage />
 </template>

--- a/app/components/LandingPageDecisionButtons.vue
+++ b/app/components/LandingPageDecisionButtons.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+defineProps<{
+  difficulty: string
+  seed: number
+  hasLastGame: boolean
+}>();
+</script>
+
+<template>
+  <UiCard class="bg-slate-800/50 border-slate-700 backdrop-blur-sm">
+    <UiCardHeader>
+      <UiCardTitle class="text-white flex items-center gap-2">
+        <NuxtIcon
+          name="lucide:play"
+          class="text-lg mr-2 text-blue-400"
+        />
+        Ready to Play?
+      </UiCardTitle>
+      <UiCardDescription class="text-slate-400">
+        Start a new game or continue your progress
+      </UiCardDescription>
+    </UiCardHeader>
+    <UiCardContent class="space-y-4">
+      <UiButton
+        class="w-full h-12 bg-orange-500 hover:bg-orange-600 text-white font-medium text-lg"
+        as-child
+      >
+        <NuxtLink :to="`/game/${difficulty}/${seed}`">
+          <NuxtIcon
+            name="lucide:play"
+            class="text-lg mr-2"
+          />
+          Start New Game
+        </NuxtLink>
+      </UiButton>
+
+      <UiButton
+        v-if="hasLastGame"
+        variant="outline"
+        class="w-full h-12 border-slate-600 text-slate-300 hover:bg-slate-700 hover:text-white"
+        as-child
+      >
+        <NuxtLink to="/game/restore">
+          <NuxtIcon
+            name="lucide:rotate-ccw"
+            class="text-lg mr-2"
+          />
+          Restore Last Game
+        </NuxtLink>
+      </UiButton>
+    </UiCardContent>
+  </UiCard>
+</template>
+
+<style scoped>
+</style>

--- a/app/components/LandingPageDifficultyOptionButton.vue
+++ b/app/components/LandingPageDifficultyOptionButton.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+defineProps<{
+  label: string
+  description: string
+  icon: string
+  selected: boolean
+}>();
+
+defineEmits<{
+  (e: 'click'): void
+}>();
+</script>
+
+<template>
+  <button
+    class="p-4 rounded-lg border-2 transition-all text-left"
+    :class="
+      selected
+        ? 'border-orange-500 bg-orange-500/10'
+        : 'border-slate-600 bg-slate-700/30 hover:border-slate-500'
+    "
+    @click="$emit('click')"
+  >
+    <div class="flex items-center gap-3">
+      <div
+        :class="[
+          'p-2 rounded',
+          selected
+            ? 'bg-orange-500/20'
+            : 'bg-slate-600/50',
+        ]"
+      >
+        <NuxtIcon
+          :name="icon"
+          class="text-white"
+        />
+      </div>
+      <div>
+        <div
+          :class="[
+            'font-medium',
+            selected
+              ? 'text-orange-300'
+              : 'text-white',
+          ]"
+        >
+          {{ label }}
+        </div>
+        <div class="text-sm text-slate-400">
+          {{ description }}
+        </div>
+      </div>
+    </div>
+  </button>
+</template>
+
+<style scoped>
+</style>

--- a/app/components/LandingPageGameSettings.vue
+++ b/app/components/LandingPageGameSettings.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+const seed = defineModel<number>('seed');
+const difficulty = defineModel<GameBoardDifficulty>('difficulty');
+</script>
+
+<template>
+  <UiCard class="bg-slate-800/50 border-slate-700 backdrop-blur-sm">
+    <UiCardHeader>
+      <UiCardTitle class="text-white flex items-center gap-2">
+        <NuxtIcon
+          name="lucide:zap"
+          class="text-lg mr-2 text-orange-400"
+        />
+        Game Settings
+      </UiCardTitle>
+      <UiCardDescription class="text-slate-400">
+        Configure your memory challenge
+      </UiCardDescription>
+    </UiCardHeader>
+    <UiCardContent class="space-y-6">
+      <div class="space-y-3">
+        <UiLabel class="text-white font-medium">
+          Difficulty Level
+        </UiLabel>
+        <div class="grid gap-3">
+          <LandingPageDifficultyOptionButton
+            label="Easy"
+            description="4x4 Grid • 8 Pairs"
+            icon="lucide:target"
+            :selected="difficulty === 'easy'"
+            @click="difficulty = 'easy'"
+          />
+          <LandingPageDifficultyOptionButton
+            label="Medium"
+            description="6x6 Grid • 18 Pairs"
+            icon="lucide:zap"
+            :selected="difficulty === 'medium'"
+            @click="difficulty = 'medium'"
+          />
+          <LandingPageDifficultyOptionButton
+            label="Hard"
+            description="8x8 Grid • 32 Pairs"
+            icon="lucide:gamepad-2"
+            :selected="difficulty === 'hard'"
+            @click="difficulty = 'hard'"
+          />
+        </div>
+      </div>
+
+      <div class="space-y-2">
+        <UiLabel
+          for="seed"
+          class="text-white font-medium"
+        >
+          <NuxtIcon
+            name="lucide:bean"
+            class="text-lg mr-2 text-green-400"
+          />
+          Game Seed
+        </UiLabel>
+        <UiInput
+          id="seed"
+          v-model="seed"
+          placeholder="Enter custom seed for reproducible games"
+          class="bg-slate-700/50 border-slate-600 text-white placeholder:text-slate-400 focus:border-orange-500"
+        />
+        <p class="text-xs text-slate-400">
+          Use the same seed to replay identical weapon layouts
+        </p>
+      </div>
+    </UiCardContent>
+  </UiCard>
+</template>
+
+<style scoped>
+</style>

--- a/app/components/LandingPageHeader.vue
+++ b/app/components/LandingPageHeader.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <header class="border-b border-gray-800 bg-gray-950">
+    <div class="container mx-auto px-4 py-6">
+      <div class="flex items-center gap-3">
+        <div class="w-10 h-10 bg-gradient-to-br from-orange-500 to-yellow-500 rounded-lg flex items-center justify-center">
+          <NuxtIcon name="lucide:target" />
+        </div>
+        <div>
+          <h1 class="text-2xl font-bold bg-gradient-to-r from-orange-400 to-yellow-400 bg-clip-text text-transparent">
+            CS2 Memory Game
+          </h1>
+          <p class="text-gray-400 text-sm">
+            Test your tactical memory skills
+          </p>
+        </div>
+      </div>
+    </div>
+  </header>
+</template>
+
+<style scoped>
+</style>

--- a/app/components/ui/badge/Badge.vue
+++ b/app/components/ui/badge/Badge.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import type { PrimitiveProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { Primitive } from 'reka-ui'
+import { cn } from '@/lib/utils'
+import { type BadgeVariants, badgeVariants } from '.'
+
+const props = defineProps<PrimitiveProps & {
+  variant?: BadgeVariants['variant']
+  class?: HTMLAttributes['class']
+}>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+</script>
+
+<template>
+  <Primitive
+    data-slot="badge"
+    :class="cn(badgeVariants({ variant }), props.class)"
+    v-bind="delegatedProps"
+  >
+    <slot />
+  </Primitive>
+</template>

--- a/app/components/ui/badge/index.ts
+++ b/app/components/ui/badge/index.ts
@@ -1,0 +1,25 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
+export { default as Badge } from './Badge.vue'
+
+export const badgeVariants = cva(
+  'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  {
+    variants: {
+      variant: {
+        default:
+          'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+        destructive:
+         'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline:
+          'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+export type BadgeVariants = VariantProps<typeof badgeVariants>

--- a/app/components/ui/card/Card.vue
+++ b/app/components/ui/card/Card.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div
+    data-slot="card"
+    :class="
+      cn(
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        props.class,
+      )
+    "
+  >
+    <slot />
+  </div>
+</template>

--- a/app/components/ui/card/CardAction.vue
+++ b/app/components/ui/card/CardAction.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div
+    data-slot="card-action"
+    :class="cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', props.class)"
+  >
+    <slot />
+  </div>
+</template>

--- a/app/components/ui/card/CardContent.vue
+++ b/app/components/ui/card/CardContent.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div
+    data-slot="card-content"
+    :class="cn('px-6', props.class)"
+  >
+    <slot />
+  </div>
+</template>

--- a/app/components/ui/card/CardDescription.vue
+++ b/app/components/ui/card/CardDescription.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <p
+    data-slot="card-description"
+    :class="cn('text-muted-foreground text-sm', props.class)"
+  >
+    <slot />
+  </p>
+</template>

--- a/app/components/ui/card/CardFooter.vue
+++ b/app/components/ui/card/CardFooter.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div
+    data-slot="card-footer"
+    :class="cn('flex items-center px-6 [.border-t]:pt-6', props.class)"
+  >
+    <slot />
+  </div>
+</template>

--- a/app/components/ui/card/CardHeader.vue
+++ b/app/components/ui/card/CardHeader.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <div
+    data-slot="card-header"
+    :class="cn('@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6', props.class)"
+  >
+    <slot />
+  </div>
+</template>

--- a/app/components/ui/card/CardTitle.vue
+++ b/app/components/ui/card/CardTitle.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <h3
+    data-slot="card-title"
+    :class="cn('leading-none font-semibold', props.class)"
+  >
+    <slot />
+  </h3>
+</template>

--- a/app/components/ui/card/index.ts
+++ b/app/components/ui/card/index.ts
@@ -1,0 +1,7 @@
+export { default as Card } from './Card.vue'
+export { default as CardAction } from './CardAction.vue'
+export { default as CardContent } from './CardContent.vue'
+export { default as CardDescription } from './CardDescription.vue'
+export { default as CardFooter } from './CardFooter.vue'
+export { default as CardHeader } from './CardHeader.vue'
+export { default as CardTitle } from './CardTitle.vue'

--- a/app/components/ui/input/Input.vue
+++ b/app/components/ui/input/Input.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { useVModel } from '@vueuse/core'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{
+  defaultValue?: string | number
+  modelValue?: string | number
+  class?: HTMLAttributes['class']
+}>()
+
+const emits = defineEmits<{
+  (e: 'update:modelValue', payload: string | number): void
+}>()
+
+const modelValue = useVModel(props, 'modelValue', emits, {
+  passive: true,
+  defaultValue: props.defaultValue,
+})
+</script>
+
+<template>
+  <input
+    v-model="modelValue"
+    data-slot="input"
+    :class="cn(
+      'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+      'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+      'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+      props.class,
+    )"
+  >
+</template>

--- a/app/components/ui/input/index.ts
+++ b/app/components/ui/input/index.ts
@@ -1,0 +1,1 @@
+export { default as Input } from './Input.vue'

--- a/app/components/ui/label/Label.vue
+++ b/app/components/ui/label/Label.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { Label, type LabelProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<LabelProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+</script>
+
+<template>
+  <Label
+    data-slot="label"
+    v-bind="delegatedProps"
+    :class="
+      cn(
+        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        props.class,
+      )
+    "
+  >
+    <slot />
+  </Label>
+</template>

--- a/app/components/ui/label/index.ts
+++ b/app/components/ui/label/index.ts
@@ -1,0 +1,1 @@
+export { default as Label } from './Label.vue'

--- a/app/composables/useGameBoardParams.ts
+++ b/app/composables/useGameBoardParams.ts
@@ -1,0 +1,31 @@
+function isDifficulty(difficulty: unknown): difficulty is GameBoardDifficulty {
+  return GAME_BOARD_DIFFICULTY.includes(difficulty as GameBoardDifficulty);
+}
+
+/**
+ * Get params from route and validate them
+ * @returns sanitized params
+ */
+export function useGameBoardParams() {
+  const { seed, difficulty } = useRoute().params;
+
+  const seedNumber = Number(seed);
+  if (isNaN(seedNumber)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid seed',
+    });
+  }
+
+  if (!isDifficulty(difficulty)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid difficulty',
+    });
+  }
+
+  return {
+    difficulty,
+    seed: seedNumber,
+  };
+};

--- a/app/pages/game/[difficulty]/[seed].vue
+++ b/app/pages/game/[difficulty]/[seed].vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+const { seed, difficulty } = useGameBoardParams();
+</script>
+
+<template>
+  <div>
+    Your game will start with Seed: <b>{{ seed }}</b> and Difficulty: <b>{{ difficulty }}</b>
+  </div>
+</template>
+
+<style scoped>
+</style>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import LandingPageDecisionButtons from '~/components/LandingPageDecisionButtons.vue';
+import LandingPageGameSettings from '~/components/LandingPageGameSettings.vue';
+
+const seed = ref(0);
+const difficulty = ref<GameBoardDifficulty>('medium');
+const hasLastGame = ref(false);
+
+onMounted(() => {
+  seed.value = Math.floor(Math.random() * 10 ** 10);
+});
+</script>
+
+<template>
+  <div className="min-h-screen bg-gray-900 text-white">
+    <LandingPageHeader />
+    <div class="grid md:grid-cols-2 gap-8 p-12">
+      <LandingPageGameSettings
+        v-model:seed="seed"
+        v-model:difficulty="difficulty"
+      />
+      <LandingPageDecisionButtons
+        :seed
+        :difficulty
+        :has-last-game
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+</style>

--- a/app/utils/gameBoardConstants.ts
+++ b/app/utils/gameBoardConstants.ts
@@ -1,0 +1,2 @@
+export const GAME_BOARD_DIFFICULTY = ['easy', 'medium', 'hard'] as const;
+export type GameBoardDifficulty = typeof GAME_BOARD_DIFFICULTY[number];

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
+    "@iconify-json/lucide": "^1.2.48",
     "@nuxt/eslint": "1.4.1",
     "@nuxt/fonts": "0.11.4",
     "@nuxt/icon": "1.13.0",
@@ -17,6 +18,7 @@
     "@nuxt/test-utils": "3.19.1",
     "@pinia/nuxt": "^0.11.1",
     "@tailwindcss/vite": "^4.1.10",
+    "@vueuse/core": "^13.3.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "eslint": "^9.29.0",
@@ -28,6 +30,7 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10",
     "tw-animate-css": "^1.3.4",
+    "typescript": "^5.8.3",
     "vue": "^3.5.16",
     "vue-router": "^4.5.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@iconify-json/lucide':
+        specifier: ^1.2.48
+        version: 1.2.48
       '@nuxt/eslint':
         specifier: 1.4.1
         version: 1.4.1(@typescript-eslint/utils@8.34.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.16)(eslint@9.29.0(jiti@2.4.2))(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(yaml@2.8.0))
@@ -29,6 +32,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.10
         version: 4.1.10(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.42.0)(yaml@2.8.0))
+      '@vueuse/core':
+        specifier: ^13.3.0
+        version: 13.3.0(vue@3.5.16(typescript@5.8.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -62,6 +68,9 @@ importers:
       tw-animate-css:
         specifier: ^1.3.4
         version: 1.3.4
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
       vue:
         specifier: ^3.5.16
         version: 3.5.16(typescript@5.8.3)
@@ -491,6 +500,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iconify-json/lucide@1.2.48':
+    resolution: {integrity: sha512-jDVqOHEF7XUwHJzx7fhwVXnx638lL89wOfmBob5UJofSGGIYV544zktmHr4CzKePslDBgl3MPKEpmFU/RfzppQ==}
 
   '@iconify/collections@1.0.558':
     resolution: {integrity: sha512-4ACVK6+8PksNTe3tVa1FJ2vcy/m9hx9dsjq8aVblWD2wAbGNqr2tVmxnm6EnKX0PON9BrrGy+U3GrqzJUSkJuw==}
@@ -1515,11 +1527,24 @@ packages:
   '@vueuse/core@12.8.2':
     resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
 
+  '@vueuse/core@13.3.0':
+    resolution: {integrity: sha512-uYRz5oEfebHCoRhK4moXFM3NSCd5vu2XMLOq/Riz5FdqZMy2RvBtazdtL3gEcmDyqkztDe9ZP/zymObMIbiYSg==}
+    peerDependencies:
+      vue: ^3.5.0
+
   '@vueuse/metadata@12.8.2':
     resolution: {integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==}
 
+  '@vueuse/metadata@13.3.0':
+    resolution: {integrity: sha512-42IzJIOYCKIb0Yjv1JfaKpx8JlCiTmtCWrPxt7Ja6Wzoq0h79+YVXmBV03N966KEmDEESTbp5R/qO3AB5BDnGw==}
+
   '@vueuse/shared@12.8.2':
     resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
+
+  '@vueuse/shared@13.3.0':
+    resolution: {integrity: sha512-L1QKsF0Eg9tiZSFXTgodYnu0Rsa2P0En2LuLrIs/jgrkyiDuJSsPZK+tx+wU0mMsYHUYEjNsuE41uqqkuR8VhA==}
+    peerDependencies:
+      vue: ^3.5.0
 
   '@whatwg-node/disposablestack@0.0.6':
     resolution: {integrity: sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==}
@@ -5150,6 +5175,10 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@iconify-json/lucide@1.2.48':
+    dependencies:
+      '@iconify/types': 2.0.0
+
   '@iconify/collections@1.0.558':
     dependencies:
       '@iconify/types': 2.0.0
@@ -6501,13 +6530,26 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  '@vueuse/core@13.3.0(vue@3.5.16(typescript@5.8.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 13.3.0
+      '@vueuse/shared': 13.3.0(vue@3.5.16(typescript@5.8.3))
+      vue: 3.5.16(typescript@5.8.3)
+
   '@vueuse/metadata@12.8.2': {}
+
+  '@vueuse/metadata@13.3.0': {}
 
   '@vueuse/shared@12.8.2(typescript@5.8.3)':
     dependencies:
       vue: 3.5.16(typescript@5.8.3)
     transitivePeerDependencies:
       - typescript
+
+  '@vueuse/shared@13.3.0(vue@3.5.16(typescript@5.8.3))':
+    dependencies:
+      vue: 3.5.16(typescript@5.8.3)
 
   '@whatwg-node/disposablestack@0.0.6':
     dependencies:


### PR DESCRIPTION
# What
Create landing page with parts that can be created without knowing how board data will look like
# Why
We need a way to set settings before game start like difficulty, seed and we need to be able to resume recent game and show personal bandleader
# How
- **/page/index.vue** Contain root of landing page where other parts of landing page live
- **/components/LandingPageHeader.vue** Raw template of simple header to push main content more to center
- **/components/LandingPageGameSettings.vue** A form-like component that allow user to set seed and difficulty. Both are binding useing v-model
- **/components/LandingPageDecisionButtons.vue** A Card where link with binding seed and difficulty waiting for user to click on it
- **/utils/gameBoardConstants.ts** Currently only GAME_BOARD_DIFFICULTY is there, but other constants probably should be put there too